### PR TITLE
fix:(workspaces): replace path with upath

### DIFF
--- a/bin/commands/fetch.js
+++ b/bin/commands/fetch.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const clipanion_1 = require("clipanion");
-const path_1 = require("path");
+const upath_1 = require("upath");
 const File_1 = require("../core/File");
 const Workspace_1 = require("../core/Workspace");
 const RestClient_1 = require("../core/HTTP/RestClient");
@@ -41,7 +41,7 @@ exports.default = async (args) => {
     if (collection.files) {
         let resource;
         for (resource of collection.files) {
-            let path = path_1.join(workspace.path, resource.path);
+            let path = upath_1.join(workspace.path, resource.path);
             let file = new File_1.default(path);
             if (await file.exists()) {
                 let shasum = await file.getShaSum();

--- a/bin/core/Config.js
+++ b/bin/core/Config.js
@@ -2,14 +2,14 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require("fs-extra");
 const yaml = require("js-yaml");
-const path_1 = require("path");
+const upath_1 = require("upath");
 class Config {
     constructor(location, filename, options = {
         encoding: 'utf8',
     }) {
         this.filename = filename;
         this.location = location;
-        this.path = path_1.join(location, filename);
+        this.path = upath_1.join(location, filename);
         this.encoding = options.encoding || 'utf8';
         this.data = null;
     }

--- a/bin/core/HTTP/RestCollection.js
+++ b/bin/core/HTTP/RestCollection.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const path_1 = require("path");
+const upath_1 = require("upath");
 class RestCollection {
     constructor(resourcePath) {
         this.resourcePath = resourcePath;
@@ -36,7 +36,7 @@ class RestCollection {
         return this.toObject();
     }
     getResourcePath(path = '') {
-        return path_1.join(this.resourcePath, path);
+        return upath_1.join(this.resourcePath, path);
     }
     static fromJSON(entity, children, json) {
         if (json.data) {

--- a/bin/core/HTTP/RestResource.js
+++ b/bin/core/HTTP/RestResource.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const path_1 = require("path");
+const upath_1 = require("upath");
 class RestResource {
     constructor(resourcePath) {
         this.resourcePath = resourcePath;
@@ -26,7 +26,7 @@ class RestResource {
         return this.toObject();
     }
     getResourcePath(path) {
-        return path_1.join(this.resourcePath, path);
+        return upath_1.join(this.resourcePath, path);
     }
     static fromJSON(child, json) {
         return new child(json);

--- a/bin/core/Workspace.js
+++ b/bin/core/Workspace.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const rs = require("recursive-readdir-async");
 const fs = require("fs-extra");
-const path = require("path");
+const path = require("upath");
 const WorkspaceTheme_1 = require("./WorkspaceTheme");
 const WorkspaceConfig_1 = require("./WorkspaceConfig");
 const WorkspacePortalConfig_1 = require("./WorkspacePortalConfig");

--- a/bin/core/WorkspaceContent.js
+++ b/bin/core/WorkspaceContent.js
@@ -2,23 +2,24 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const rs = require("recursive-readdir-async");
 const fs = require("fs-extra");
-const path_1 = require("path");
+const upath_1 = require("upath");
 const File_1 = require("./File");
 const FileResource_1 = require("./HTTP/Resources/FileResource");
 class WorkspaceContent {
     constructor(location) {
-        this.location = location;
-        this.path = path_1.join(location, 'content');
+        this.location = upath_1.toUnix(location);
+        this.path = upath_1.join(location, 'content');
         this.files = null;
     }
     async scan() {
         this.files = await rs.list(this.path, { exclude: ['.DS_Store'] });
         if (this.files) {
             this.files = this.files.map((file) => {
+                const unixName = upath_1.toUnix(file.fullname);
                 return {
-                    file: new File_1.default(file.fullname),
+                    file: new File_1.default(unixName),
                     resource: new FileResource_1.default({
-                        path: file.fullname.replace(`${this.location}/`, ''),
+                        path: unixName.replace(`${this.location}/`, ''),
                         contents: '',
                     }),
                 };
@@ -48,7 +49,7 @@ class WorkspaceContent {
         }
     }
     static getDirectoryPath(location) {
-        return path_1.join(location, 'content');
+        return upath_1.join(location, 'content');
     }
 }
 exports.default = WorkspaceContent;

--- a/bin/core/WorkspaceSpecs.js
+++ b/bin/core/WorkspaceSpecs.js
@@ -2,23 +2,24 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const rs = require("recursive-readdir-async");
 const fs = require("fs-extra");
-const path_1 = require("path");
+const upath_1 = require("upath");
 const File_1 = require("./File");
 const FileResource_1 = require("./HTTP/Resources/FileResource");
 class WorkspaceSpecs {
     constructor(location) {
         this.location = location;
-        this.path = path_1.join(location, 'specs');
+        this.path = upath_1.join(location, 'specs');
         this.files = null;
     }
     async scan() {
         this.files = await rs.list(this.path, { exclude: ['.DS_Store'] });
         if (this.files) {
             this.files = this.files.map((file) => {
+                const unixName = upath_1.toUnix(file.fullname);
                 return {
-                    file: new File_1.default(file.fullname),
+                    file: new File_1.default(unixName),
                     resource: new FileResource_1.default({
-                        path: file.fullname.replace(`${this.location}/`, ''),
+                        path: unixName.replace(`${this.location}/`, ''),
                         contents: '',
                     }),
                 };
@@ -48,7 +49,7 @@ class WorkspaceSpecs {
         }
     }
     static getDirectoryPath(location) {
-        return path_1.join(location, 'specs');
+        return upath_1.join(location, 'specs');
     }
 }
 exports.default = WorkspaceSpecs;

--- a/bin/core/WorkspaceTheme.js
+++ b/bin/core/WorkspaceTheme.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const rs = require("recursive-readdir-async");
 const fs = require("fs-extra");
-const path_1 = require("path");
+const upath_1 = require("upath");
 const WorkspaceThemeConfig_1 = require("./WorkspaceThemeConfig");
 const FileResource_1 = require("./HTTP/Resources/FileResource");
 const File_1 = require("./File");
@@ -12,9 +12,9 @@ class WorkspaceTheme {
         this.location = location;
         this.path = WorkspaceTheme.getDirectoryPath(location, name);
         this.config = new WorkspaceThemeConfig_1.default(this.path, 'theme.conf.yaml');
-        this.assetsPath = path_1.join(this.path, 'assets');
-        this.layoutsPath = path_1.join(this.path, 'layouts');
-        this.partialsPath = path_1.join(this.path, 'partials');
+        this.assetsPath = upath_1.join(this.path, 'assets');
+        this.layoutsPath = upath_1.join(this.path, 'layouts');
+        this.partialsPath = upath_1.join(this.path, 'partials');
         this.assets = null;
         this.layouts = null;
         this.partials = null;
@@ -33,10 +33,11 @@ class WorkspaceTheme {
     }
     mapFilesToContent(files) {
         return files.map((file) => {
+            const unixName = upath_1.toUnix(file.fullname);
             return {
-                file: new File_1.default(file.fullname),
+                file: new File_1.default(unixName),
                 resource: new FileResource_1.default({
-                    path: file.fullname.replace(this.location + '/', ''),
+                    path: unixName.replace(this.location + '/', ''),
                     contents: '',
                 }),
             };
@@ -76,7 +77,7 @@ class WorkspaceTheme {
         }
     }
     static getDirectoryPath(location, name) {
-        return path_1.join(location, 'themes', name);
+        return upath_1.join(location, 'themes', name);
     }
 }
 exports.default = WorkspaceTheme;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2153,6 +2153,11 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
+    "upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "got": "^9.6.0",
     "js-yaml": "^3.13.1",
     "ora": "^3.4.0",
-    "recursive-readdir-async": "^1.1.5"
+    "recursive-readdir-async": "^1.1.5",
+    "upath": "^1.2.0"
   },
   "devDependencies": {
     "@types/got": "^9.6.0",

--- a/src/commands/fetch.ts
+++ b/src/commands/fetch.ts
@@ -1,5 +1,5 @@
 import { UsageError } from 'clipanion';
-import { join } from 'path';
+import { join } from 'upath';
 
 import File from '../core/File';
 import Workspace from '../core/Workspace';
@@ -65,7 +65,7 @@ export default async (args): Promise<void> => {
       }
     }
   }
-  
+
   if (!modified || added) {
     console.log(`\t`, `No changes.`)
   }

--- a/src/commands/wipe.ts
+++ b/src/commands/wipe.ts
@@ -1,5 +1,5 @@
 import { UsageError } from 'clipanion';
-import { join } from 'path';
+import { join } from 'upath';
 
 import Workspace from '../core/Workspace';
 import RestClient from '../core/HTTP/RestClient';

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
 import * as yaml from 'js-yaml';
-import { join } from 'path';
+import { join } from 'upath';
 
 export default class Config {
   public filename: string;

--- a/src/core/HTTP/RestCollection.ts
+++ b/src/core/HTTP/RestCollection.ts
@@ -1,5 +1,5 @@
 import { IRestCollection, IRestResponse } from './RestInterfaces';
-import { join } from 'path';
+import { join } from 'upath';
 import RestClient from './RestClient';
 
 export default class RestCollection implements IRestCollection {

--- a/src/core/HTTP/RestResource.ts
+++ b/src/core/HTTP/RestResource.ts
@@ -1,5 +1,5 @@
 import { IRestResource, IRestResponse } from './RestInterfaces';
-import { join } from 'path';
+import { join } from 'upath';
 import RestClient from './RestClient';
 
 export default class RestResource implements IRestResource {

--- a/src/core/Workspace.ts
+++ b/src/core/Workspace.ts
@@ -1,6 +1,6 @@
 import * as rs from 'recursive-readdir-async';
 import * as fs from 'fs-extra';
-import * as path from 'path';
+import * as path from 'upath';
 
 import WorkspaceTheme from './WorkspaceTheme';
 import WorkspaceConfig from './WorkspaceConfig';

--- a/src/core/WorkspaceContent.ts
+++ b/src/core/WorkspaceContent.ts
@@ -1,6 +1,6 @@
 import * as rs from 'recursive-readdir-async';
 import * as fs from 'fs-extra';
-import { join } from 'path';
+import { join, toUnix } from 'upath'
 import File from './File';
 import FileResource from './HTTP/Resources/FileResource';
 
@@ -16,7 +16,7 @@ export default class WorkspaceContent {
   public files: Content[] | null;
 
   public constructor(location: string) {
-    this.location = location;
+    this.location = toUnix(location);
     this.path = join(location, 'content');
 
     this.files = null;
@@ -28,10 +28,11 @@ export default class WorkspaceContent {
     if (this.files) {
       this.files = this.files.map(
         (file: any): Content => {
+          const unixName = toUnix(file.fullname)
           return {
-            file: new File(file.fullname),
+            file: new File(unixName),
             resource: new FileResource({
-              path: file.fullname.replace(`${this.location}/`, ''),
+              path: unixName.replace(`${this.location}/`, ''),
               contents: '',
             }),
           };

--- a/src/core/WorkspaceSpecs.ts
+++ b/src/core/WorkspaceSpecs.ts
@@ -1,6 +1,6 @@
 import * as rs from 'recursive-readdir-async';
 import * as fs from 'fs-extra';
-import { join } from 'path';
+import { join, toUnix } from 'upath';
 import File from './File';
 import FileResource from './HTTP/Resources/FileResource';
 
@@ -28,10 +28,11 @@ export default class WorkspaceSpecs {
     if (this.files) {
       this.files = this.files.map(
         (file: any): Spec => {
+          const unixName = toUnix(file.fullname)
           return {
-            file: new File(file.fullname),
+            file: new File(unixName),
             resource: new FileResource({
-              path: file.fullname.replace(`${this.location}/`, ''),
+              path: unixName.replace(`${this.location}/`, ''),
               contents: '',
             }),
           };

--- a/src/core/WorkspaceTheme.ts
+++ b/src/core/WorkspaceTheme.ts
@@ -1,6 +1,6 @@
 import * as rs from 'recursive-readdir-async';
 import * as fs from 'fs-extra';
-import { join } from 'path';
+import { join, toUnix } from 'upath';
 
 import WorkspaceThemeConfig from './WorkspaceThemeConfig';
 import { Content } from './WorkspaceContent';
@@ -56,10 +56,11 @@ export default class WorkspaceTheme {
   private mapFilesToContent(files: Record<string, any>[]): Content[] {
     return files.map(
       (file: any): Content => {
+        const unixName = toUnix(file.fullname)
         return {
-          file: new File(file.fullname),
+          file: new File(unixName),
           resource: new FileResource({
-            path: file.fullname.replace(this.location + '/', ''),
+            path: unixName.replace(this.location + '/', ''),
             contents: '',
           }),
         };


### PR DESCRIPTION
This PR replaces all uses of path with upath https://www.npmjs.com/package/upath in order to force posix style pathing. This is required because the path value uploaded to kong must be in posix-style. 

While replacing all uses is not strictly required to make this fix, maintaining consistency will make maintenance easier. 

Any areas where file location is manually accessed without a join the location is wrapped around a upath.toUnix call. This is required as there are some manual `.replace` operations done on file locations that depend on `/` . 

Tested manually on windows 10.