### PR TITLE
feat(env) allow for env variables to override cli.conf.yaml values

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,21 +28,34 @@ Make sure Kong is running and portal is on:
 
 Now from root folder of the templates repo you can run:
 
-```portal [-h,--help] [--config PATH] [-v,--verbose] <command>```
+```portal <command> <workspace>```
 
 Where `<command>` is one of:
- - `config`   Output or change configuration of the portal on the given
- - `workspace`, locally.
- - `deploy`   Deploy changes made locally under the given workspace upstream.
- - `disable`  Enable the portal on the given workspace.
- - `enable`   Enable the portal on the given workspace.
- - `fetch`    Fetches content and themes from the given workspace.
- - `serve`    Run the portal of a given workspace locally.
- - `wipe`     Deletes all content and themes from upstream workspace
+ - `config`    Output or change configuration of the portal on the given
+ - `deploy`    Deploy changes made locally under the given workspace upstream.
+ - `disable`   Enable the portal on the given workspace.
+ - `enable`    Enable the portal on the given workspace.
+ - `fetch`     Fetches content and themes from the given workspace.
+ - `serve`     Run the portal of a given workspace locally.
+ - `wipe`      Deletes all content and themes from upstream workspace
+
+ Where `<workspace>` indicates the directory/workspace pairing you would like to operate on.
 
 Add `--watch` to make changes reactive
 
 
+### Using Environment Variables
+You can override config values set in `cli.conf.yaml` via environment variables.  If you wanted to override the kong admin url for example, you can run:
+
+```
+ADMIN_URL=http://new-admin-url.com portal deploy default
+```
+
+Environment variables are useful for scripting as well as temporarily overriding particular settings.
+
+Available environment variables include:
+  - `ADMIN_URL` URL the CLI should target for uploading files
+  - `RBAC_TOKEN` Kong Admin RBAC token used to authenticate with the Kong Admin API
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For Kong Enterprise `<= 0.36`, or for `legacy mode` on Kong Enterprise `>= 1.3` 
 ## Usage
 The easiest way to start is by cloning the [portal-templates repo][templates] dev-master branch locally.
 
-Then edit `workspaces/default/cli.conf.yaml` to set workspace `name` and `rbac_token` to match your setup.
+Then edit `workspaces/default/cli.conf.yaml` to set `kong_admin_uri` and `kong_admin_token` to match your setup.
 
 Make sure Kong is running and portal is on:
 
@@ -48,14 +48,14 @@ Add `--watch` to make changes reactive
 You can override config values set in `cli.conf.yaml` via environment variables.  If you wanted to override the kong admin url for example, you can run:
 
 ```
-ADMIN_URL=http://new-admin-url.com portal deploy default
+KONG_ADMIN_URL=http://new-admin-url.com portal deploy default
 ```
 
 Environment variables are useful for scripting as well as temporarily overriding particular settings.
 
 Available environment variables include:
-  - `ADMIN_URL` URL the CLI should target for uploading files
-  - `RBAC_TOKEN` Kong Admin RBAC token used to authenticate with the Kong Admin API
+  - `KONG_ADMIN_URL` Kong Admin URL the CLI should target for uploading files
+  - `KONG_ADMIN_TOKEN` Kong Admin Token token used to authenticate with the Kong Admin API
 
 ## Contributing
 

--- a/bin/commands/compare.js
+++ b/bin/commands/compare.js
@@ -1,1 +1,5 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = async () => {
+    console.log('"compare" command not yet implemented. \n');
+};

--- a/bin/commands/deploy.js
+++ b/bin/commands/deploy.js
@@ -193,7 +193,7 @@ async function Deploy(workspace, path) {
     let repository;
     let collection;
     try {
-        client = new RestClient_1.default(workspace.config);
+        client = new RestClient_1.default(workspace.config, workspace.name);
         repository = new FileRepository_1.default(client);
         collection = await repository.getFiles();
         console.log(`Deploying ${workspace.name}:`);

--- a/bin/commands/disable.js
+++ b/bin/commands/disable.js
@@ -1,1 +1,5 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = async () => {
+    console.log('"disable" command not yet implemented. \n');
+};

--- a/bin/commands/enable.js
+++ b/bin/commands/enable.js
@@ -1,1 +1,5 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = async () => {
+    console.log('"enable" command not yet implemented. \n');
+};

--- a/bin/commands/fetch.js
+++ b/bin/commands/fetch.js
@@ -30,11 +30,11 @@ exports.default = async (args) => {
     console.log(`Config:`);
     console.log(``);
     console.log(`\t`, `Workspace:`, workspace.name);
-    if (workspace.config.adminUrl) {
-        console.log(`\t`, `Workspace Upstream:`, `${workspace.config.adminUrl}/${workspace.name}`, workspace.config.rbacToken ? `(authenticated)` : ``);
+    if (workspace.config.kongAdminUrl) {
+        console.log(`\t`, `Workspace Upstream:`, `${workspace.config.kongAdminUrl}/${workspace.name}`, workspace.config.kongAdminToken ? `(authenticated)` : ``);
     }
     else if (workspace.config.upstream) {
-        console.log(`\t`, `Workspace Upstream:`, `${workspace.config.upstream}`, workspace.config.rbacToken ? `(authenticated)` : ``);
+        console.log(`\t`, `Workspace Upstream:`, `${workspace.config.upstream}`, workspace.config.kongAdminToken ? `(authenticated)` : ``);
     }
     console.log(`\t`, `Workspace Directory:`, workspace.path);
     console.log(``);

--- a/bin/commands/fetch.js
+++ b/bin/commands/fetch.js
@@ -25,12 +25,17 @@ exports.default = async (args) => {
     catch (e) {
         return MissingWorkspaceError(args.workspace);
     }
-    client = new RestClient_1.default(workspace.config);
+    client = new RestClient_1.default(workspace.config, workspace.name);
     repository = new FileRepository_1.default(client);
     console.log(`Config:`);
     console.log(``);
     console.log(`\t`, `Workspace:`, workspace.name);
-    console.log(`\t`, `Workspace Upstream:`, workspace.config.upstream, workspace.config.rbacToken ? `(authenticated)` : ``);
+    if (workspace.config.adminUrl) {
+        console.log(`\t`, `Workspace Upstream:`, `${workspace.config.adminUrl}/${workspace.name}`, workspace.config.rbacToken ? `(authenticated)` : ``);
+    }
+    else if (workspace.config.upstream) {
+        console.log(`\t`, `Workspace Upstream:`, `${workspace.config.upstream}`, workspace.config.rbacToken ? `(authenticated)` : ``);
+    }
     console.log(`\t`, `Workspace Directory:`, workspace.path);
     console.log(``);
     console.log(`Changes:`);

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -1,1 +1,5 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = async () => {
+    console.log('"new" command not yet implemented. \n');
+};

--- a/bin/commands/serve.js
+++ b/bin/commands/serve.js
@@ -1,1 +1,5 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = async () => {
+    console.log('"serve" command not yet implemented. \n');
+};

--- a/bin/commands/wipe.js
+++ b/bin/commands/wipe.js
@@ -23,7 +23,7 @@ exports.default = async (args) => {
     catch (e) {
         return MissingWorkspaceError(args.workspace);
     }
-    client = new RestClient_1.default(workspace.config);
+    client = new RestClient_1.default(workspace.config, workspace.name);
     repository = new FileRepository_1.default(client);
     let collection = await repository.getFiles();
     if (collection.files) {

--- a/bin/core/HTTP/RestClient.js
+++ b/bin/core/HTTP/RestClient.js
@@ -9,9 +9,18 @@ class RestClientError extends Error {
 }
 exports.RestClientError = RestClientError;
 class RestClient {
-    constructor(workspaceConfig) {
+    constructor(workspaceConfig, workspaceName) {
         this.clientHeaders = workspaceConfig.headers || {};
-        this.clientUrl = workspaceConfig.upstream;
+        if (workspaceConfig.adminUrl) {
+            this.clientUrl = `${workspaceConfig.adminUrl}/${workspaceName}`;
+        }
+        else if (workspaceConfig.upstream) {
+            console.log('upstream is deprecated and will cease to function in a later release. Please use admin_url (upstream url without the workspace suffix)');
+            this.clientUrl = workspaceConfig.upstream;
+        }
+        else {
+            this.clientUrl = '';
+        }
         if (workspaceConfig.rbacToken) {
             this.clientHeaders['Kong-Admin-Token'] = workspaceConfig.rbacToken;
         }

--- a/bin/core/HTTP/RestClient.js
+++ b/bin/core/HTTP/RestClient.js
@@ -11,18 +11,18 @@ exports.RestClientError = RestClientError;
 class RestClient {
     constructor(workspaceConfig, workspaceName) {
         this.clientHeaders = workspaceConfig.headers || {};
-        if (workspaceConfig.adminUrl) {
-            this.clientUrl = `${workspaceConfig.adminUrl}/${workspaceName}`;
+        if (workspaceConfig.kongAdminUrl) {
+            this.clientUrl = `${workspaceConfig.kongAdminUrl}/${workspaceName}`;
         }
         else if (workspaceConfig.upstream) {
-            console.log('upstream is deprecated and will cease to function in a later release. Please use admin_url (upstream url without the workspace suffix)');
+            console.log('upstream is deprecated and will cease to function in a later release. Please use kong_admin_url (upstream url without the workspace suffix)');
             this.clientUrl = workspaceConfig.upstream;
         }
         else {
             this.clientUrl = '';
         }
-        if (workspaceConfig.rbacToken) {
-            this.clientHeaders['Kong-Admin-Token'] = workspaceConfig.rbacToken;
+        if (workspaceConfig.kongAdminToken) {
+            this.clientHeaders['Kong-Admin-Token'] = workspaceConfig.kongAdminToken;
         }
         this.client = got.extend({
             baseUrl: this.clientUrl,

--- a/bin/core/Workspace.js
+++ b/bin/core/Workspace.js
@@ -56,6 +56,15 @@ class Workspace {
     static async init(name) {
         const workspace = new Workspace(name);
         await workspace.config.load();
+        if (process.env.WORKSPACE_NAME) {
+            workspace.config.data.name = process.env.WORKSPACE_NAME;
+        }
+        if (process.env.UPSTREAM) {
+            workspace.config.data.upstream = process.env.UPSTREAM;
+        }
+        if (process.env.RBAC_TOKEN) {
+            workspace.config.data.rbac_token = process.env.RBAC_TOKEN;
+        }
         await workspace.portalConfig.load();
         await workspace.routerConfig.load();
         return workspace;

--- a/bin/core/Workspace.js
+++ b/bin/core/Workspace.js
@@ -56,11 +56,8 @@ class Workspace {
     static async init(name) {
         const workspace = new Workspace(name);
         await workspace.config.load();
-        if (process.env.WORKSPACE_NAME) {
-            workspace.config.data.name = process.env.WORKSPACE_NAME;
-        }
-        if (process.env.UPSTREAM) {
-            workspace.config.data.upstream = process.env.UPSTREAM;
+        if (process.env.ADMIN_URL) {
+            workspace.config.data.admin_url = process.env.ADMIN_URL;
         }
         if (process.env.RBAC_TOKEN) {
             workspace.config.data.rbac_token = process.env.RBAC_TOKEN;

--- a/bin/core/Workspace.js
+++ b/bin/core/Workspace.js
@@ -56,11 +56,11 @@ class Workspace {
     static async init(name) {
         const workspace = new Workspace(name);
         await workspace.config.load();
-        if (process.env.ADMIN_URL) {
-            workspace.config.data.admin_url = process.env.ADMIN_URL;
+        if (process.env.KONG_ADMIN_URL) {
+            workspace.config.data.kong_admin_url = process.env.KONG_ADMIN_URL;
         }
-        if (process.env.RBAC_TOKEN) {
-            workspace.config.data.rbac_token = process.env.RBAC_TOKEN;
+        if (process.env.KONG_ADMIN_TOKEN) {
+            workspace.config.data.kong_admin_token = process.env.KONG_ADMIN_TOKEN;
         }
         await workspace.portalConfig.load();
         await workspace.routerConfig.load();

--- a/bin/core/WorkspaceConfig.js
+++ b/bin/core/WorkspaceConfig.js
@@ -14,11 +14,11 @@ class WorkspaceConfig extends Config_1.default {
     set description(text) {
         this.data.description = text;
     }
-    get adminUrl() {
-        return this.data.admin_url;
+    get kongAdminUrl() {
+        return this.data.kong_admin_url;
     }
-    set adminUrl(url) {
-        this.data.admin_url = url;
+    set kongAdminUrl(url) {
+        this.data.kong_admin_url = url;
     }
     get upstream() {
         return this.data.upstream;
@@ -32,11 +32,11 @@ class WorkspaceConfig extends Config_1.default {
     set headers(headers) {
         this.data.headers = headers;
     }
-    get rbacToken() {
-        return this.data.rbac_token;
+    get kongAdminToken() {
+        return this.data.kong_admin_token;
     }
-    set rbacToken(token) {
-        this.data.rbac_token = token;
+    set kongAdminToken(token) {
+        this.data.kong_admin_token = token;
     }
 }
 exports.default = WorkspaceConfig;

--- a/bin/core/WorkspaceConfig.js
+++ b/bin/core/WorkspaceConfig.js
@@ -14,6 +14,12 @@ class WorkspaceConfig extends Config_1.default {
     set description(text) {
         this.data.description = text;
     }
+    get adminUrl() {
+        return this.data.admin_url;
+    }
+    set adminUrl(url) {
+        this.data.admin_url = url;
+    }
     get upstream() {
         return this.data.upstream;
     }

--- a/bin/portal.js
+++ b/bin/portal.js
@@ -2,10 +2,12 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const clipanion_1 = require("clipanion");
-clipanion_1.clipanion.topLevel(`[-v,--verbose]`);
 const deploy_1 = require("./commands/deploy");
 const wipe_1 = require("./commands/wipe");
 const fetch_1 = require("./commands/fetch");
+const disable_1 = require("./commands/disable");
+const enable_1 = require("./commands/enable");
+const serve_1 = require("./commands/serve");
 clipanion_1.clipanion
     .command(`deploy <workspace> [--watch]`)
     .describe(`Deploy changes made locally under the given workspace upstream.`)
@@ -25,13 +27,13 @@ clipanion_1.clipanion
 clipanion_1.clipanion
     .command(`enable <workspace>`)
     .describe(`Enable the portal on the given workspace.`)
-    .action(require('./commands/enable'));
+    .action(enable_1.default);
 clipanion_1.clipanion
     .command(`disable <workspace>`)
     .describe(`Enable the portal on the given workspace.`)
-    .action(require('./commands/disable'));
+    .action(disable_1.default);
 clipanion_1.clipanion
     .command(`serve <workspace>`)
     .describe(`Run the portal of a given workspace locally.`)
-    .action(require('./commands/serve'));
+    .action(serve_1.default);
 clipanion_1.clipanion.runExit('portal', process.argv.slice(2));

--- a/src/commands/compare.ts
+++ b/src/commands/compare.ts
@@ -1,0 +1,3 @@
+export default async (): Promise<void> => {
+  console.log('"compare" command not yet implemented. \n');
+};

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -244,7 +244,7 @@ async function Deploy(workspace: Workspace, path?: any): Promise<void> {
   let collection: FilesCollection;
 
   try {
-    client = new RestClient(workspace.config);
+    client = new RestClient(workspace.config, workspace.name);
     repository = new FilesRepository(client);
     collection = await repository.getFiles();
 

--- a/src/commands/disable.ts
+++ b/src/commands/disable.ts
@@ -1,0 +1,3 @@
+export default async (): Promise<void> => {
+  console.log('"disable" command not yet implemented. \n');
+};

--- a/src/commands/enable.ts
+++ b/src/commands/enable.ts
@@ -1,0 +1,3 @@
+export default async (): Promise<void> => {
+  console.log('"enable" command not yet implemented. \n');
+};

--- a/src/commands/fetch.ts
+++ b/src/commands/fetch.ts
@@ -38,10 +38,10 @@ export default async (args): Promise<void> => {
   console.log(``);
   console.log(`\t`,`Workspace:`, workspace.name);
 
-  if (workspace.config.adminUrl) {
-    console.log(`\t`,`Workspace Upstream:`, `${workspace.config.adminUrl}/${workspace.name}`, workspace.config.rbacToken ? `(authenticated)` : ``);
+  if (workspace.config.kongAdminUrl) {
+    console.log(`\t`,`Workspace Upstream:`, `${workspace.config.kongAdminUrl}/${workspace.name}`, workspace.config.kongAdminToken ? `(authenticated)` : ``);
   } else if (workspace.config.upstream) {
-    console.log(`\t`,`Workspace Upstream:`, `${workspace.config.upstream}`, workspace.config.rbacToken ? `(authenticated)` : ``);
+    console.log(`\t`,`Workspace Upstream:`, `${workspace.config.upstream}`, workspace.config.kongAdminToken ? `(authenticated)` : ``);
   }
 
   console.log(`\t`,`Workspace Directory:`, workspace.path);

--- a/src/commands/fetch.ts
+++ b/src/commands/fetch.ts
@@ -30,13 +30,20 @@ export default async (args): Promise<void> => {
     return MissingWorkspaceError(args.workspace);
   }
 
-  client = new RestClient(workspace.config);
+  client = new RestClient(workspace.config, workspace.name);
   repository = new FilesRepository(client);
+
 
   console.log(`Config:`);
   console.log(``);
   console.log(`\t`,`Workspace:`, workspace.name);
-  console.log(`\t`,`Workspace Upstream:`, workspace.config.upstream, workspace.config.rbacToken ? `(authenticated)` : ``);
+
+  if (workspace.config.adminUrl) {
+    console.log(`\t`,`Workspace Upstream:`, `${workspace.config.adminUrl}/${workspace.name}`, workspace.config.rbacToken ? `(authenticated)` : ``);
+  } else if (workspace.config.upstream) {
+    console.log(`\t`,`Workspace Upstream:`, `${workspace.config.upstream}`, workspace.config.rbacToken ? `(authenticated)` : ``);
+  }
+
   console.log(`\t`,`Workspace Directory:`, workspace.path);
   console.log(``);
   console.log(`Changes:`);

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,0 +1,3 @@
+export default async (): Promise<void> => {
+  console.log('"new" command not yet implemented. \n');
+};

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,0 +1,3 @@
+export default async (): Promise<void> => {
+  console.log('"serve" command not yet implemented. \n');
+};

--- a/src/commands/wipe.ts
+++ b/src/commands/wipe.ts
@@ -29,7 +29,7 @@ export default async (args): Promise<void> => {
     return MissingWorkspaceError(args.workspace);
   }
 
-  client = new RestClient(workspace.config);
+  client = new RestClient(workspace.config, workspace.name);
   repository = new FilesRepository(client);
 
   let collection = await repository.getFiles();

--- a/src/core/HTTP/RestClient.ts
+++ b/src/core/HTTP/RestClient.ts
@@ -17,9 +17,17 @@ export default class RestClient {
   public clientHeaders: OutgoingHttpHeaders;
   public clientUrl: string;
 
-  public constructor(workspaceConfig: IWorkspaceConfig) {
+  public constructor(workspaceConfig: IWorkspaceConfig, workspaceName: String) {
     this.clientHeaders = workspaceConfig.headers || {};
-    this.clientUrl = workspaceConfig.upstream;
+
+    if (workspaceConfig.adminUrl) {
+      this.clientUrl = `${workspaceConfig.adminUrl}/${workspaceName}`
+    } else if (workspaceConfig.upstream) {
+      console.log('upstream is deprecated and will cease to function in a later release. Please use admin_url (upstream url without the workspace suffix)')
+      this.clientUrl = workspaceConfig.upstream
+    } else {
+      this.clientUrl = ''
+    }
 
     if (workspaceConfig.rbacToken) {
       this.clientHeaders['Kong-Admin-Token'] = workspaceConfig.rbacToken;

--- a/src/core/HTTP/RestClient.ts
+++ b/src/core/HTTP/RestClient.ts
@@ -20,17 +20,17 @@ export default class RestClient {
   public constructor(workspaceConfig: IWorkspaceConfig, workspaceName: String) {
     this.clientHeaders = workspaceConfig.headers || {};
 
-    if (workspaceConfig.adminUrl) {
-      this.clientUrl = `${workspaceConfig.adminUrl}/${workspaceName}`
+    if (workspaceConfig.kongAdminUrl) {
+      this.clientUrl = `${workspaceConfig.kongAdminUrl}/${workspaceName}`
     } else if (workspaceConfig.upstream) {
-      console.log('upstream is deprecated and will cease to function in a later release. Please use admin_url (upstream url without the workspace suffix)')
+      console.log('upstream is deprecated and will cease to function in a later release. Please use kong_admin_url (upstream url without the workspace suffix)')
       this.clientUrl = workspaceConfig.upstream
     } else {
       this.clientUrl = ''
     }
 
-    if (workspaceConfig.rbacToken) {
-      this.clientHeaders['Kong-Admin-Token'] = workspaceConfig.rbacToken;
+    if (workspaceConfig.kongAdminToken) {
+      this.clientHeaders['Kong-Admin-Token'] = workspaceConfig.kongAdminToken;
     }
 
     this.client = got.extend({

--- a/src/core/Workspace.ts
+++ b/src/core/Workspace.ts
@@ -76,12 +76,8 @@ export default class Workspace {
     const workspace = new Workspace(name);
     await workspace.config.load();
 
-    if (process.env.WORKSPACE_NAME) {
-      workspace.config.data.name = process.env.WORKSPACE_NAME
-    }
-
-    if (process.env.UPSTREAM) {
-      workspace.config.data.upstream = process.env.UPSTREAM
+    if (process.env.ADMIN_URL) {
+      workspace.config.data.admin_url = process.env.ADMIN_URL
     }
 
     if (process.env.RBAC_TOKEN) {

--- a/src/core/Workspace.ts
+++ b/src/core/Workspace.ts
@@ -76,12 +76,12 @@ export default class Workspace {
     const workspace = new Workspace(name);
     await workspace.config.load();
 
-    if (process.env.ADMIN_URL) {
-      workspace.config.data.admin_url = process.env.ADMIN_URL
+    if (process.env.KONG_ADMIN_URL) {
+      workspace.config.data.kong_admin_url = process.env.KONG_ADMIN_URL
     }
 
-    if (process.env.RBAC_TOKEN) {
-      workspace.config.data.rbac_token = process.env.RBAC_TOKEN
+    if (process.env.KONG_ADMIN_TOKEN) {
+      workspace.config.data.kong_admin_token = process.env.KONG_ADMIN_TOKEN
     }
 
     await workspace.portalConfig.load();

--- a/src/core/Workspace.ts
+++ b/src/core/Workspace.ts
@@ -75,6 +75,19 @@ export default class Workspace {
   public static async init(name: string): Promise<Workspace> {
     const workspace = new Workspace(name);
     await workspace.config.load();
+
+    if (process.env.WORKSPACE_NAME) {
+      workspace.config.data.name = process.env.WORKSPACE_NAME
+    }
+
+    if (process.env.UPSTREAM) {
+      workspace.config.data.upstream = process.env.UPSTREAM
+    }
+
+    if (process.env.RBAC_TOKEN) {
+      workspace.config.data.rbac_token = process.env.RBAC_TOKEN
+    }
+
     await workspace.portalConfig.load();
     await workspace.routerConfig.load();
 

--- a/src/core/WorkspaceConfig.ts
+++ b/src/core/WorkspaceConfig.ts
@@ -4,16 +4,19 @@ import { OutgoingHttpHeaders } from './HTTP/RestInterfaces';
 export interface IWorkspaceConfig {
   name?: string;
   description?: string;
-  upstream: string;
+  upstream?: string;
+  adminUrl?: string;
   headers?: OutgoingHttpHeaders;
   rbacToken?: string;
 }
 
 export default class WorkspaceConfig extends Config implements IWorkspaceConfig {
+  // deprecated
   public get name(): string {
     return this.data.name;
   }
 
+  // deprecated
   public set name(name: string) {
     this.data.name = name;
   }
@@ -26,10 +29,22 @@ export default class WorkspaceConfig extends Config implements IWorkspaceConfig 
     this.data.description = text;
   }
 
+  public get adminUrl(): string {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    return this.data.admin_url;
+  }
+
+  public set adminUrl(url: string) {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    this.data.admin_url = url;
+  }
+
+  // deprecated
   public get upstream(): string {
     return this.data.upstream;
   }
 
+  // deprecated
   public set upstream(url: string) {
     this.data.upstream = url;
   }

--- a/src/core/WorkspaceConfig.ts
+++ b/src/core/WorkspaceConfig.ts
@@ -5,9 +5,9 @@ export interface IWorkspaceConfig {
   name?: string;
   description?: string;
   upstream?: string;
-  adminUrl?: string;
   headers?: OutgoingHttpHeaders;
-  rbacToken?: string;
+  kongAdminUrl?: string;
+  kongAdminToken?: string;
 }
 
 export default class WorkspaceConfig extends Config implements IWorkspaceConfig {
@@ -29,14 +29,14 @@ export default class WorkspaceConfig extends Config implements IWorkspaceConfig 
     this.data.description = text;
   }
 
-  public get adminUrl(): string {
+  public get kongAdminUrl(): string {
     // eslint-disable-next-line @typescript-eslint/camelcase
-    return this.data.admin_url;
+    return this.data.kong_admin_url;
   }
 
-  public set adminUrl(url: string) {
+  public set kongAdminUrl(url: string) {
     // eslint-disable-next-line @typescript-eslint/camelcase
-    this.data.admin_url = url;
+    this.data.kong_admin_url = url;
   }
 
   // deprecated
@@ -57,13 +57,13 @@ export default class WorkspaceConfig extends Config implements IWorkspaceConfig 
     this.data.headers = headers;
   }
 
-  public get rbacToken(): string {
+  public get kongAdminToken(): string {
     // eslint-disable-next-line @typescript-eslint/camelcase
-    return this.data.rbac_token;
+    return this.data.kong_admin_token;
   }
 
-  public set rbacToken(token: string) {
+  public set kongAdminToken(token: string) {
     // eslint-disable-next-line @typescript-eslint/camelcase
-    this.data.rbac_token = token;
+    this.data.kong_admin_token = token;
   }
 }

--- a/src/portal.ts
+++ b/src/portal.ts
@@ -2,11 +2,13 @@
 
 import { clipanion } from 'clipanion';
 
-clipanion.topLevel(`[-v,--verbose]`);
-
 import DeployCommand from './commands/deploy';
 import WipeCommand from './commands/wipe';
 import FetchCommand from './commands/fetch';
+import DisableCommand from './commands/disable';
+import EnableCommand from './commands/enable';
+import ServeCommand from './commands/serve';
+
 
 clipanion
   .command(`deploy <workspace> [--watch]`)
@@ -31,16 +33,16 @@ clipanion
 clipanion
   .command(`enable <workspace>`)
   .describe(`Enable the portal on the given workspace.`)
-  .action(require('./commands/enable'));
+  .action(EnableCommand);
 
 clipanion
   .command(`disable <workspace>`)
   .describe(`Enable the portal on the given workspace.`)
-  .action(require('./commands/disable'));
+  .action(DisableCommand);
 
 clipanion
   .command(`serve <workspace>`)
   .describe(`Run the portal of a given workspace locally.`)
-  .action(require('./commands/serve'));
+  .action(ServeCommand);
 
 clipanion.runExit('portal', process.argv.slice(2));


### PR DESCRIPTION
This PR allows for `cli.conf.yaml` values to be overwritten by env vars.

```
KONG_ADMIN_URL=http://localhost:8001 KONG_ADMIN_TOKEN=something portal deploy default
```

This PR also adds a new conf value: `kong_admin_url`. This is used in the place of `upstream` and is equivalent to the upstream minus the workspace suffix.

`uptream` still functions but will log a deprication warning when used. `upstream` CANNOT be set via environment variables.

Additionally, `rbac_token` has been renamed to `kong_admin_token` to match the actually conf value in Kong