### PR TITLE
feat(enable/disable): add enable/disable commands

### DIFF
--- a/bin/commands/disable.js
+++ b/bin/commands/disable.js
@@ -1,5 +1,46 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.default = async () => {
-    console.log('"disable" command not yet implemented. \n');
+const clipanion_1 = require("clipanion");
+const RestClient_1 = require("../core/HTTP/RestClient");
+const WorkspaceRepository_1 = require("../core/HTTP/Repositories/WorkspaceRepository");
+const Workspace_1 = require("../core/Workspace");
+const ora = require("ora");
+function MissingWorkspaceError(name) {
+    const message = [
+        `No workspace named "${name}" was found.`,
+        ``,
+        `Directories scanned:`,
+        `\t${Workspace_1.default.getDirectoryPath(name)}`,
+    ];
+    throw new clipanion_1.UsageError(message.join('\n'));
+}
+;
+exports.default = async (args) => {
+    let workspace;
+    let client;
+    try {
+        workspace = await Workspace_1.default.init(args.workspace);
+    }
+    catch (e) {
+        return MissingWorkspaceError(args.workspace);
+    }
+    let spinner = ora({
+        prefixText: `Disabling ${workspace.name} Portal...`
+    });
+    spinner.start();
+    try {
+        client = new RestClient_1.default(workspace.config, workspace.name);
+        let wsRepository = new WorkspaceRepository_1.default(client);
+        let ws = await wsRepository.getWorkspace(workspace.name);
+        ws.config.portal = false;
+        await client.save(ws, {
+            body: ws.toObject()
+        });
+        spinner.prefixText = `\t`;
+        spinner.text = `'${workspace.name}' Portal Disabled`;
+        spinner.succeed();
+    }
+    catch (e) {
+        spinner.fail(e.message);
+    }
 };

--- a/bin/commands/enable.js
+++ b/bin/commands/enable.js
@@ -1,5 +1,46 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.default = async () => {
-    console.log('"enable" command not yet implemented. \n');
+const clipanion_1 = require("clipanion");
+const RestClient_1 = require("../core/HTTP/RestClient");
+const WorkspaceRepository_1 = require("../core/HTTP/Repositories/WorkspaceRepository");
+const Workspace_1 = require("../core/Workspace");
+const ora = require("ora");
+function MissingWorkspaceError(name) {
+    const message = [
+        `No workspace named "${name}" was found.`,
+        ``,
+        `Directories scanned:`,
+        `\t${Workspace_1.default.getDirectoryPath(name)}`,
+    ];
+    throw new clipanion_1.UsageError(message.join('\n'));
+}
+;
+exports.default = async (args) => {
+    let workspace;
+    let client;
+    try {
+        workspace = await Workspace_1.default.init(args.workspace);
+    }
+    catch (e) {
+        return MissingWorkspaceError(args.workspace);
+    }
+    let spinner = ora({
+        prefixText: `Enabling ${workspace.name} Portal...`
+    });
+    spinner.start();
+    try {
+        client = new RestClient_1.default(workspace.config, workspace.name);
+        let wsRepository = new WorkspaceRepository_1.default(client);
+        let ws = await wsRepository.getWorkspace(workspace.name);
+        ws.config.portal = true;
+        await client.save(ws, {
+            body: ws.toObject()
+        });
+        spinner.prefixText = `\t`;
+        spinner.text = `'${workspace.name}' Portal Enabled`;
+        spinner.succeed();
+    }
+    catch (e) {
+        spinner.fail(e.message);
+    }
 };

--- a/bin/core/HTTP/Collections/WorkspacesCollection.js
+++ b/bin/core/HTTP/Collections/WorkspacesCollection.js
@@ -1,0 +1,18 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const WorkspaceResource_1 = require("../Resources/WorkspaceResource");
+const RestCollection_1 = require("../RestCollection");
+class WorkspacesCollection extends RestCollection_1.default {
+    constructor(json) {
+        super('/workspaces');
+        this.workspaces = json.data || json.files || [];
+        this.next = json.next;
+    }
+    async getNext() {
+        return super.getNext(this.next, WorkspacesCollection);
+    }
+    static fromJSON(json) {
+        return RestCollection_1.default.fromJSON(WorkspacesCollection, WorkspaceResource_1.default, json);
+    }
+}
+exports.default = WorkspacesCollection;

--- a/bin/core/HTTP/Repositories/WorkspaceRepository.js
+++ b/bin/core/HTTP/Repositories/WorkspaceRepository.js
@@ -1,0 +1,32 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const WorkspacesCollection_1 = require("../Collections/WorkspacesCollection");
+const WorkspaceResource_1 = require("../Resources/WorkspaceResource");
+class WorkspaceRepository {
+    constructor(client) {
+        this.path = '/workspaces';
+        this.client = client;
+    }
+    async getWorkspaces() {
+        try {
+            let response = await this.client.get(this.path);
+            let collection = WorkspacesCollection_1.default.fromJSON(response.result);
+            collection.client = this.client;
+            if (collection.workspaces) {
+                collection.workspaces.forEach((file) => {
+                    file.client = this.client;
+                });
+            }
+            return collection;
+        }
+        catch (e) {
+            throw e;
+        }
+    }
+    async getWorkspace(path) {
+        let response = await this.client.get("workspaces/" + path);
+        let resource = WorkspaceResource_1.default.fromJSON(response.result);
+        return resource;
+    }
+}
+exports.default = WorkspaceRepository;

--- a/bin/core/HTTP/Resources/WorkspaceResource.js
+++ b/bin/core/HTTP/Resources/WorkspaceResource.js
@@ -1,0 +1,18 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const RestResource_1 = require("../RestResource");
+class WorkspaceResource extends RestResource_1.default {
+    constructor(json) {
+        super('/workspaces');
+        this.id = json.id;
+        this.name = json.name;
+        this.config = json.config;
+    }
+    getResourcePath() {
+        return super.getResourcePath(this.id || this.name);
+    }
+    static fromJSON(json) {
+        return RestResource_1.default.fromJSON(WorkspaceResource, json);
+    }
+}
+exports.default = WorkspaceResource;

--- a/bin/core/HTTP/RestClient.js
+++ b/bin/core/HTTP/RestClient.js
@@ -45,6 +45,7 @@ class RestClient {
         options.body = resource.toObject();
         try {
             let response = await this.client.put(resource.getResourcePath(), options);
+            console.log(response);
             return this.handleResponse(response);
         }
         catch (e) {

--- a/bin/core/HTTP/RestClient.js
+++ b/bin/core/HTTP/RestClient.js
@@ -45,7 +45,6 @@ class RestClient {
         options.body = resource.toObject();
         try {
             let response = await this.client.put(resource.getResourcePath(), options);
-            console.log(response);
             return this.handleResponse(response);
         }
         catch (e) {

--- a/bin/portal.js
+++ b/bin/portal.js
@@ -30,7 +30,7 @@ clipanion_1.clipanion
     .action(enable_1.default);
 clipanion_1.clipanion
     .command(`disable <workspace>`)
-    .describe(`Enable the portal on the given workspace.`)
+    .describe(`Disable the portal on the given workspace.`)
     .action(disable_1.default);
 clipanion_1.clipanion
     .command(`serve <workspace>`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kong-portal-cli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/commands/disable.ts
+++ b/src/commands/disable.ts
@@ -1,3 +1,52 @@
-export default async (): Promise<void> => {
-  console.log('"disable" command not yet implemented. \n');
+import { UsageError } from 'clipanion';
+
+import RestClient from '../core/HTTP/RestClient';
+import WorkspaceRepository from '../core/HTTP/Repositories/WorkspaceRepository';
+import Workspace from '../core/Workspace';
+import * as ora from 'ora';
+
+function MissingWorkspaceError(name: string): void {
+  const message: string[] = [
+    `No workspace named "${name}" was found.`,
+    ``,
+    `Directories scanned:`,
+    `\t${Workspace.getDirectoryPath(name)}`,
+  ];
+
+  throw new UsageError(message.join('\n'));
+};
+
+export default async (args): Promise<void> => {
+  let workspace: Workspace;
+  let client: RestClient;
+
+  try {
+    workspace = await Workspace.init(args.workspace);
+  } catch (e) {
+    return MissingWorkspaceError(args.workspace);
+  }
+
+  let spinner: ora.Ora = ora({
+    prefixText: `Disabling ${workspace.name} Portal...`
+  });
+
+  spinner.start();
+
+  try {
+    client = new RestClient(workspace.config, workspace.name);
+    let wsRepository = new WorkspaceRepository(client);
+    let ws = await wsRepository.getWorkspace(workspace.name);
+
+    ws.config.portal = false;
+    await client.save(ws, {
+      body: ws.toObject()
+    });
+
+    spinner.prefixText = `\t`;
+    spinner.text = `'${workspace.name}' Portal Disabled`;
+    spinner.succeed();
+
+  } catch (e) {
+    spinner.fail(e.message);
+  }
 };

--- a/src/commands/enable.ts
+++ b/src/commands/enable.ts
@@ -1,3 +1,52 @@
-export default async (): Promise<void> => {
-  console.log('"enable" command not yet implemented. \n');
+import { UsageError } from 'clipanion';
+
+import RestClient from '../core/HTTP/RestClient';
+import WorkspaceRepository from '../core/HTTP/Repositories/WorkspaceRepository';
+import Workspace from '../core/Workspace';
+import * as ora from 'ora';
+
+function MissingWorkspaceError(name: string): void {
+  const message: string[] = [
+    `No workspace named "${name}" was found.`,
+    ``,
+    `Directories scanned:`,
+    `\t${Workspace.getDirectoryPath(name)}`,
+  ];
+
+  throw new UsageError(message.join('\n'));
+};
+
+export default async (args): Promise<void> => {
+  let workspace: Workspace;
+  let client: RestClient;
+
+  try {
+    workspace = await Workspace.init(args.workspace);
+  } catch (e) {
+    return MissingWorkspaceError(args.workspace);
+  }
+
+  let spinner: ora.Ora = ora({
+    prefixText: `Enabling ${workspace.name} Portal...`
+  });
+
+  spinner.start();
+
+  try {
+    client = new RestClient(workspace.config, workspace.name);
+    let wsRepository = new WorkspaceRepository(client);
+    let ws = await wsRepository.getWorkspace(workspace.name);
+
+    ws.config.portal = true;
+    await client.save(ws, {
+      body: ws.toObject()
+    });
+
+    spinner.prefixText = `\t`;
+    spinner.text = `'${workspace.name}' Portal Enabled`;
+    spinner.succeed();
+
+  } catch (e) {
+    spinner.fail(e.message);
+  }
 };

--- a/src/core/HTTP/Collections/WorkspacesCollection.ts
+++ b/src/core/HTTP/Collections/WorkspacesCollection.ts
@@ -1,0 +1,33 @@
+import WorkspaceResource from '../Resources/WorkspaceResource';
+import RestCollection from '../RestCollection';
+
+export interface WorkspacesCollectionJSON {
+  data: [];
+  next: string | null;
+}
+
+export interface IWorkspacesCollection {
+  data?: WorkspaceResource[];
+  files?: WorkspaceResource[];
+  next: string | null;
+}
+
+export default class WorkspacesCollection extends RestCollection {
+  public workspaces: WorkspaceResource[];
+  public next: string | null;
+
+  public constructor(json: IWorkspacesCollection) {
+    super('/workspaces');
+
+    this.workspaces = json.data || json.files || [];
+    this.next = json.next;
+  }
+
+  public async getNext(): Promise<WorkspacesCollection | void> {
+    return super.getNext(this.next, WorkspacesCollection);
+  }
+
+  public static fromJSON(json: WorkspacesCollectionJSON): WorkspacesCollection {
+    return RestCollection.fromJSON(WorkspacesCollection, WorkspaceResource, json) as WorkspacesCollection;
+  }
+}

--- a/src/core/HTTP/Repositories/WorkspaceRepository.ts
+++ b/src/core/HTTP/Repositories/WorkspaceRepository.ts
@@ -1,0 +1,39 @@
+import RestClient from '../RestClient';
+import WorkspacesCollection, { WorkspacesCollectionJSON } from '../Collections/WorkspacesCollection';
+import WorkspaceResource, { WorkspaceResourceJSON } from '../Resources/WorkspaceResource';
+
+export default class WorkspaceRepository {
+  private path: string;
+  private client: RestClient;
+
+  public constructor(client: RestClient) {
+    this.path = '/workspaces';
+    this.client = client;
+  }
+
+  public async getWorkspaces(): Promise<WorkspacesCollection> {
+    try {
+      let response = await this.client.get<WorkspacesCollectionJSON>(this.path);
+      let collection = WorkspacesCollection.fromJSON(response.result);
+
+      collection.client = this.client;
+
+      if (collection.workspaces) {
+        collection.workspaces.forEach((file: WorkspaceResource): void => {
+          file.client = this.client;
+        });
+      }
+
+      return collection;
+    } catch (e) {
+      throw e;
+    }
+  }
+
+  public async getWorkspace(path: string): Promise<WorkspaceResource> {
+    let response = await this.client.get<WorkspaceResourceJSON>("workspaces/" + path);
+    let resource = WorkspaceResource.fromJSON(response.result);
+    // resource.client = this.client;
+    return resource;
+  }
+}

--- a/src/core/HTTP/Resources/WorkspaceResource.ts
+++ b/src/core/HTTP/Resources/WorkspaceResource.ts
@@ -1,0 +1,32 @@
+import RestResource from '../RestResource';
+
+export interface WorkspaceResourceJSON {
+  /** UUID */
+  id?: string;
+  /** File path from workspace root */
+  name: string;
+  /** Workspace config */
+  config: any;
+}
+
+export default class WorkspaceResource extends RestResource implements WorkspaceResourceJSON {
+  public id?: string;
+  public name: string;
+  public config: any;
+
+  public constructor(json: WorkspaceResourceJSON) {
+    super('/workspaces');
+
+    this.id = json.id;
+    this.name = json.name;
+    this.config = json.config;
+  }
+
+  public getResourcePath(): string {
+    return super.getResourcePath(this.id || this.name);
+  }
+
+  public static fromJSON(json: WorkspaceResourceJSON): WorkspaceResource {
+    return RestResource.fromJSON(WorkspaceResource, json) as WorkspaceResource;
+  }
+}

--- a/src/core/HTTP/RestClient.ts
+++ b/src/core/HTTP/RestClient.ts
@@ -17,7 +17,7 @@ export default class RestClient {
   public clientHeaders: OutgoingHttpHeaders;
   public clientUrl: string;
 
-  public constructor(workspaceConfig: IWorkspaceConfig, workspaceName: String) {
+  public constructor(workspaceConfig: IWorkspaceConfig, workspaceName: string) {
     this.clientHeaders = workspaceConfig.headers || {};
 
     if (workspaceConfig.kongAdminUrl) {

--- a/src/portal.ts
+++ b/src/portal.ts
@@ -37,7 +37,7 @@ clipanion
 
 clipanion
   .command(`disable <workspace>`)
-  .describe(`Enable the portal on the given workspace.`)
+  .describe(`Disable the portal on the given workspace.`)
   .action(DisableCommand);
 
 clipanion


### PR DESCRIPTION
The Portal CLI can now enable or disable a workspaces portal via command.
Example: 'portal enable default'