### PR TITLE
feat(Workspace): impove error handling

### DIFF
--- a/src/core/Workspace.ts
+++ b/src/core/Workspace.ts
@@ -26,6 +26,9 @@ export default class Workspace {
   }
 
   public static async init(name: string): Promise<Workspace> {
+    if ((await this.exists(name)) === false) {
+      throw new Error()
+    }
     const workspace = new Workspace(name)
     await workspace.config.load()
     await workspace.portalConfig.load()


### PR DESCRIPTION
Gives nicer error when workspace folder doesn't exist by throwing error earlier.

test by running "portal <deploy/wipe/config/> nonexistant_ws