### PR TITLE
chore(*): switch to new clipanion and add version text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kong-portal-cli",
-  "version": "2.0.1",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -279,11 +279,6 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
-    "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -336,49 +331,11 @@
       "dev": true
     },
     "clipanion": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-0.15.0.tgz",
-      "integrity": "sha512-nrH+X/+fRovpPj7Qw2Q6hlXD8WW//IIqPXPCE1rq8iNMGtfHS3FqSI2reH/rZk1iJ8AYLrT6NLhJvbYP9BNdVw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-2.3.1.tgz",
+      "integrity": "sha512-1LbN8W3mkb+YHwiyi5DX9eOjeSg7yqpn98+jJZh3nUFUBFZDh/I5PadYV/64KC6SKEOmSxNUGa7uN3HIsX8O/Q==",
       "requires": {
-        "camelcase": "^5.2.0",
-        "chalk": "^1.1.3"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
+        "chalk": "^2.4.2"
       }
     },
     "clone": {
@@ -872,21 +829,6 @@
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        }
-      }
     },
     "has-flag": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "CLI tool to manage your Kong Developer Portals for Kong Enterprise",
   "main": "index.js",
   "bin": {
-    "portal": "./bin/portal.js"
+    "portal": "./bin/src/portal.js"
   },
   "scripts": {
-    "build": "rm -rf bin && tsc && chmod +x ./bin/portal.js",
+    "build": "rm -rf bin && tsc && chmod +x ./bin/src/portal.js",
     "prepublishOnly": "npm run build"
   },
   "repository": {
@@ -33,7 +33,7 @@
     "body-parser": "^1.19.0",
     "chalk": "^2.4.2",
     "chokidar": "^3.0.1",
-    "clipanion": "^0.15.0",
+    "clipanion": "^2.3.1",
     "crypto-promise": "^2.1.0",
     "fs-extra": "^8.0.1",
     "isbinaryfile": "^4.0.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 
 {
   "compilerOptions": {
+    "resolveJsonModule": true,
+    "experimentalDecorators": true,
     "noImplicitAny": false,
     "noImplicitThis": true,
     "alwaysStrict": true,
@@ -13,7 +15,7 @@
     "noUnusedParameters": false,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    
+
     "target": "es2017",
     "module": "commonjs",
     "moduleResolution": "node",
@@ -27,7 +29,8 @@
     ]
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "package.json"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This PR address https://github.com/Kong/kong-portal-cli/issues/39 by switching to latest clipanion
In doing so portal.ts was refactored.

https://github.com/Kong/kong-portal-cli/issues/38 is also resolved by adding a --version command.


As part of the portal.ts refactor/updated clipanion there is now --help enabled on commands like `portal deploy --help`


Note to reviewers: If you are using npm-link/yarn-link you may need to relink  after building because the bin location has been changed.