### PR TITLE
Feat/tdx 936 dissable ssl verifcation

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -110,7 +110,7 @@ export default async (args: any): Promise<void> => {
   let workspace: Workspace
 
   try {
-    workspace = await Workspace.init(args.workspace)
+    workspace = await Workspace.init(args.workspace, args.disableSSLVerification)
   } catch (e) {
     return MissingWorkspaceError(args.workspace)
   }

--- a/src/commands/disable.ts
+++ b/src/commands/disable.ts
@@ -9,7 +9,7 @@ export default async (args): Promise<void> => {
   let client: RestClient
 
   try {
-    workspace = await Workspace.init(args.workspace)
+    workspace = await Workspace.init(args.workspace, args.disableSSLVerification)
   } catch (e) {
     return MissingWorkspaceError(args.workspace)
   }

--- a/src/commands/enable.ts
+++ b/src/commands/enable.ts
@@ -9,7 +9,7 @@ export default async (args): Promise<void> => {
   let client: RestClient
 
   try {
-    workspace = await Workspace.init(args.workspace)
+    workspace = await Workspace.init(args.workspace, args.disableSSLVerification)
   } catch (e) {
     return MissingWorkspaceError(args.workspace)
   }

--- a/src/commands/fetch.ts
+++ b/src/commands/fetch.ts
@@ -33,7 +33,7 @@ export default async (args): Promise<void> => {
   let client: RestClient
 
   try {
-    workspace = await Workspace.init(args.workspace)
+    workspace = await Workspace.init(args.workspace, args.disableSSLVerification)
   } catch (e) {
     return MissingWorkspaceError(args.workspace)
   }

--- a/src/commands/wipe.ts
+++ b/src/commands/wipe.ts
@@ -10,7 +10,7 @@ export default async (args): Promise<void> => {
   let client: RestClient
 
   try {
-    workspace = await Workspace.init(args.workspace)
+    workspace = await Workspace.init(args.workspace, args.disableSSLVerification)
   } catch (e) {
     return MissingWorkspaceError(args.workspace)
   }

--- a/src/core/HTTP/RestClient.ts
+++ b/src/core/HTTP/RestClient.ts
@@ -2,6 +2,7 @@ import { IWorkspaceConfig } from '../WorkspaceConfig'
 import { OutgoingHttpHeaders, IRestResponse, IRestResource } from './RestInterfaces'
 import FileResource, { FileResourceJSON } from './Resources/FileResource'
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios'
+import * as https from 'https'
 
 export class RestClientError<T> extends Error {
   public response: IRestResponse<T>
@@ -45,9 +46,18 @@ export default class RestClient {
       this.clientHeaders['Kong-Admin-Token'] = workspaceConfig.kongAdminToken
     }
 
+    let httpsAgent
+
+    if (workspaceConfig.disableSSLVerification) {
+      httpsAgent = new https.Agent({
+        rejectUnauthorized: false,
+      })
+    }
+
     this.client = axios.create({
       baseURL: this.clientUrl,
       headers: this.clientHeaders,
+      httpsAgent,
     })
   }
 

--- a/src/core/Workspace.ts
+++ b/src/core/Workspace.ts
@@ -25,7 +25,7 @@ export default class Workspace {
     this.routerConfig = new Config(this.path, 'router.conf.yaml')
   }
 
-  public static async init(name: string): Promise<Workspace> {
+  public static async init(name: string, disableSSLVerification?: boolean): Promise<Workspace> {
     if ((await this.exists(name)) === false) {
       throw new Error()
     }
@@ -42,6 +42,10 @@ export default class Workspace {
     if (process.env.KONG_ADMIN_TOKEN) {
       // eslint-disable-next-line @typescript-eslint/camelcase
       workspace.config.data.kong_admin_token = process.env.KONG_ADMIN_TOKEN
+    }
+
+    if (disableSSLVerification) {
+      workspace.config.data.disableSSLVerification = true
     }
 
     return workspace

--- a/src/core/WorkspaceConfig.ts
+++ b/src/core/WorkspaceConfig.ts
@@ -2,12 +2,14 @@ import Config from './Config'
 import { OutgoingHttpHeaders } from './HTTP/RestInterfaces'
 
 export interface IWorkspaceConfig {
+  data: {}
   name?: string
   description?: string
   upstream?: string
   headers?: OutgoingHttpHeaders
   kongAdminUrl?: string
   kongAdminToken?: string
+  disableSSLVerification?: boolean
 }
 
 export default class WorkspaceConfig extends Config implements IWorkspaceConfig {
@@ -66,4 +68,15 @@ export default class WorkspaceConfig extends Config implements IWorkspaceConfig 
     // eslint-disable-next-line @typescript-eslint/camelcase
     this.data.kong_admin_token = token
   }
+
+  public set disableSSLVerification(isDisable: boolean) {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    this.data.disable_ssl_verification = isDisable
+  }
+
+  public get disableSSLVerification(): boolean {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    return this.data.disable_ssl_verification
+  }
+
 }

--- a/src/core/WorkspaceConfig.ts
+++ b/src/core/WorkspaceConfig.ts
@@ -9,11 +9,8 @@ export interface IWorkspaceConfig {
   headers?: OutgoingHttpHeaders
   kongAdminUrl?: string
   kongAdminToken?: string
-<<<<<<< HEAD
   disableSSLVerification?: boolean
-=======
   ignoreSpecs?: boolean
->>>>>>> master
 }
 
 export default class WorkspaceConfig extends Config implements IWorkspaceConfig {
@@ -73,7 +70,6 @@ export default class WorkspaceConfig extends Config implements IWorkspaceConfig 
     this.data.kong_admin_token = token
   }
 
-<<<<<<< HEAD
   public set disableSSLVerification(isDisable: boolean) {
     // eslint-disable-next-line @typescript-eslint/camelcase
     this.data.disable_ssl_verification = isDisable
@@ -84,7 +80,6 @@ export default class WorkspaceConfig extends Config implements IWorkspaceConfig 
     return this.data.disable_ssl_verification
   }
 
-=======
   public set ignoreSpecs(isIgnore: boolean) {
     // eslint-disable-next-line @typescript-eslint/camelcase
     this.data.ignore_specs = isIgnore
@@ -94,5 +89,4 @@ export default class WorkspaceConfig extends Config implements IWorkspaceConfig 
     // eslint-disable-next-line @typescript-eslint/camelcase
     return this.data.ignore_specs
   }
->>>>>>> master
 }

--- a/src/portal.ts
+++ b/src/portal.ts
@@ -59,6 +59,9 @@ class FetchCommand extends Command {
   @Command.Boolean(`-K,--keep-encode`)
   public keep_encode: boolean = false
 
+  @Command.Boolean(`-D,--disable-ssl-verification`)
+  public disableSSLVerification: boolean = false
+
   @Command.Path(`fetch`)
   public async execute(): Promise<void> {
     await Fetch(this)
@@ -72,6 +75,9 @@ class WipeCommand extends Command {
 
   @Command.String({ required: true })
   public workspace!: string
+
+  @Command.Boolean(`-D,--disable-ssl-verification`)
+  public disableSSLVerification: boolean = false
 
   @Command.Path(`wipe`)
   public async execute(): Promise<void> {
@@ -101,6 +107,9 @@ class EnableCommand extends Command {
   @Command.String({ required: true })
   public workspace!: string
 
+  @Command.Boolean(`-D,--disable-ssl-verification`)
+  public disableSSLVerification: boolean = false
+
   @Command.Path(`enable`)
   public async execute(): Promise<void> {
     await Enable(this)
@@ -114,6 +123,9 @@ class DisableCommand extends Command {
 
   @Command.String({ required: true })
   public workspace!: string
+
+  @Command.Boolean(`-D,--disable-ssl-verification`)
+  public disableSSLVerification: boolean = false
 
   @Command.Path(`disable`)
   public async execute(): Promise<void> {

--- a/src/portal.ts
+++ b/src/portal.ts
@@ -35,6 +35,9 @@ class DeployCommand extends Command {
   @Command.Boolean(`-W,--watch`)
   public watch: boolean = false
 
+  @Command.Boolean(`-D,--disable-ssl-verification`)
+  public disableSSLVerification: boolean = false
+
   @Command.Path(`deploy`)
   public async execute(): Promise<void> {
     await Deploy(this)

--- a/src/portal.ts
+++ b/src/portal.ts
@@ -35,13 +35,10 @@ class DeployCommand extends Command {
   @Command.Boolean(`-W,--watch`)
   public watch: boolean = false
 
-<<<<<<< HEAD
   @Command.Boolean(`-D,--disable-ssl-verification`)
   public disableSSLVerification: boolean = false
-=======
   @Command.Boolean(`-I,--ignore-specs`)
   public ignoreSpecs: boolean = false
->>>>>>> master
 
   @Command.Path(`deploy`)
   public async execute(): Promise<void> {
@@ -84,13 +81,10 @@ class WipeCommand extends Command {
   @Command.String({ required: true })
   public workspace!: string
 
-<<<<<<< HEAD
   @Command.Boolean(`-D,--disable-ssl-verification`)
   public disableSSLVerification: boolean = false
-=======
   @Command.Boolean(`-I,--ignore-specs`)
   public ignoreSpecs: boolean = false
->>>>>>> master
 
   @Command.Path(`wipe`)
   public async execute(): Promise<void> {


### PR DESCRIPTION
This PR adds disable_ssl_verification to the cli.conf, when set to true, self signed certs will be considered valid.

This can also be triggered by using `-D` or `--disable-ssl-verification` on deploy, fetch, wipe, enable, and disable.