### PR TITLE
Feat/tdx 937 ignore specs

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -110,7 +110,7 @@ export default async (args: any): Promise<void> => {
   let workspace: Workspace
 
   try {
-    workspace = await Workspace.init(args.workspace)
+    workspace = await Workspace.init(args.workspace, args.ignoreSpecs)
   } catch (e) {
     return MissingWorkspaceError(args.workspace)
   }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -67,12 +67,14 @@ async function Deploy(workspace: Workspace, path?: any): Promise<void> {
 
     if (files.length > 0) {
       fileObj['other files'] = files
-      console.log(files)
     }
 
     await asyncForEach(
       Object.keys(fileObj),
       async (fileType): Promise<void> => {
+        if (fileType === 'specs' && workspace.config.ignoreSpecs) {
+          return
+        }
         let files: File[] = fileObj[fileType]
         spinner.prefixText = `Deploying ${fileType}`
         for (let file of files) {
@@ -90,7 +92,9 @@ async function Deploy(workspace: Workspace, path?: any): Promise<void> {
     )
     spinner.prefixText = ''
     if (!path) {
-      spinner.text = `Deployed all files to ${workspace.name}`
+      spinner.text = workspace.config.ignoreSpecs
+        ? `Deployed all non-spec files to ${workspace.name}`
+        : `Deployed all files to ${workspace.name}`
     }
     spinner.succeed()
 

--- a/src/commands/fetch.ts
+++ b/src/commands/fetch.ts
@@ -33,7 +33,7 @@ export default async (args): Promise<void> => {
   let client: RestClient
 
   try {
-    workspace = await Workspace.init(args.workspace)
+    workspace = await Workspace.init(args.workspace, args.ignoreSpecs)
   } catch (e) {
     return MissingWorkspaceError(args.workspace)
   }
@@ -49,26 +49,35 @@ export default async (args): Promise<void> => {
 
   let added = 0
   let modified = 0
+  let specs = 0
 
   if (response) {
     for (let resource of response) {
+      if (workspace.config.ignoreSpecs && resource.path.startsWith('specs')) {
+        specs++
+        continue
+      }
       let path: string = join(workspace.path, resource.path)
       let file: File = new File(path, workspace.path)
       if (await file.exists()) {
         if (await shouldRewriteFile(resource, file, args.keepEncode)) {
           file.write(resource.contents)
           console.log('\t', 'Modified:', resource.path)
-          modified += 1
+          modified++
         }
       } else {
         file.write(resource.contents)
         console.log('\t', 'Added:', resource.path)
-        added += 1
+        added++
       }
     }
   }
 
   console.log('\t', `Fetched ${response.length} files`)
+
+  if (specs) {
+    console.log('\t', `Ignored ${specs} specs`)
+  }
 
   if (!modified || added) {
     console.log('\t', 'No changes.')

--- a/src/commands/wipe.ts
+++ b/src/commands/wipe.ts
@@ -10,7 +10,7 @@ export default async (args): Promise<void> => {
   let client: RestClient
 
   try {
-    workspace = await Workspace.init(args.workspace)
+    workspace = await Workspace.init(args.workspace, args.ignoreSpecs)
   } catch (e) {
     return MissingWorkspaceError(args.workspace)
   }
@@ -24,10 +24,12 @@ export default async (args): Promise<void> => {
 
   let files: FileResource[]
   try {
-
     files = await client.getAllFiles()
 
     for (let file of files) {
+      if (workspace.config.ignoreSpecs && file.path.startsWith('specs')) {
+        continue
+      }
       spinner.text = file.path
       await client.deleteFile(file)
     }
@@ -38,6 +40,8 @@ export default async (args): Promise<void> => {
   }
 
   spinner.prefixText = `\t`
-  spinner.text = `Wiped all Files from ${workspace.name}`
+  spinner.text = workspace.config.ignoreSpecs
+    ? `Wiped all non-spec Files from ${workspace.name}`
+    : `Wiped all Files from ${workspace.name}`
   spinner.succeed()
 }

--- a/src/core/Workspace.ts
+++ b/src/core/Workspace.ts
@@ -45,7 +45,8 @@ export default class Workspace {
     }
 
     if (ignoreSpecs) {
-      workspace.config.data.ignoreSpecs = true
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      workspace.config.data.ignore_specs = true
     }
 
     return workspace

--- a/src/core/Workspace.ts
+++ b/src/core/Workspace.ts
@@ -25,7 +25,7 @@ export default class Workspace {
     this.routerConfig = new Config(this.path, 'router.conf.yaml')
   }
 
-  public static async init(name: string): Promise<Workspace> {
+  public static async init(name: string, ignoreSpecs?: boolean): Promise<Workspace> {
     if ((await this.exists(name)) === false) {
       throw new Error()
     }
@@ -42,6 +42,10 @@ export default class Workspace {
     if (process.env.KONG_ADMIN_TOKEN) {
       // eslint-disable-next-line @typescript-eslint/camelcase
       workspace.config.data.kong_admin_token = process.env.KONG_ADMIN_TOKEN
+    }
+
+    if (ignoreSpecs) {
+      workspace.config.data.ignoreSpecs = true
     }
 
     return workspace

--- a/src/core/WorkspaceConfig.ts
+++ b/src/core/WorkspaceConfig.ts
@@ -8,6 +8,7 @@ export interface IWorkspaceConfig {
   headers?: OutgoingHttpHeaders
   kongAdminUrl?: string
   kongAdminToken?: string
+  ignoreSpecs?: boolean
 }
 
 export default class WorkspaceConfig extends Config implements IWorkspaceConfig {
@@ -65,5 +66,15 @@ export default class WorkspaceConfig extends Config implements IWorkspaceConfig 
   public set kongAdminToken(token: string) {
     // eslint-disable-next-line @typescript-eslint/camelcase
     this.data.kong_admin_token = token
+  }
+
+  public set ignoreSpecs(isDisable: boolean) {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    this.data.disable_ssl_verification = isDisable
+  }
+
+  public get ignoreSpecs(): boolean {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    return this.data.disable_ssl_verification
   }
 }

--- a/src/core/WorkspaceConfig.ts
+++ b/src/core/WorkspaceConfig.ts
@@ -68,13 +68,13 @@ export default class WorkspaceConfig extends Config implements IWorkspaceConfig 
     this.data.kong_admin_token = token
   }
 
-  public set ignoreSpecs(isDisable: boolean) {
+  public set ignoreSpecs(isIgnore: boolean) {
     // eslint-disable-next-line @typescript-eslint/camelcase
-    this.data.disable_ssl_verification = isDisable
+    this.data.ignore_specs = isIgnore
   }
 
   public get ignoreSpecs(): boolean {
     // eslint-disable-next-line @typescript-eslint/camelcase
-    return this.data.disable_ssl_verification
+    return this.data.ignore_specs
   }
 }

--- a/src/portal.ts
+++ b/src/portal.ts
@@ -35,6 +35,9 @@ class DeployCommand extends Command {
   @Command.Boolean(`-W,--watch`)
   public watch: boolean = false
 
+  @Command.Boolean(`-i,--ignore-specs`)
+  public ignore_specs: boolean = false
+
   @Command.Path(`deploy`)
   public async execute(): Promise<void> {
     await Deploy(this)
@@ -56,6 +59,9 @@ class FetchCommand extends Command {
   @Command.Boolean(`-K,--keep-encode`)
   public keep_encode: boolean = false
 
+  @Command.Boolean(`-i,--ignore-specs`)
+  public ignore_specs: boolean = false
+
   @Command.Path(`fetch`)
   public async execute(): Promise<void> {
     await Fetch(this)
@@ -69,6 +75,9 @@ class WipeCommand extends Command {
 
   @Command.String({ required: true })
   public workspace!: string
+
+  @Command.Boolean(`-i,--ignore-specs`)
+  public ignore_specs: boolean = false
 
   @Command.Path(`wipe`)
   public async execute(): Promise<void> {

--- a/src/portal.ts
+++ b/src/portal.ts
@@ -35,8 +35,8 @@ class DeployCommand extends Command {
   @Command.Boolean(`-W,--watch`)
   public watch: boolean = false
 
-  @Command.Boolean(`-i,--ignore-specs`)
-  public ignore_specs: boolean = false
+  @Command.Boolean(`-I,--ignore-specs`)
+  public ignoreSpecs: boolean = false
 
   @Command.Path(`deploy`)
   public async execute(): Promise<void> {
@@ -57,10 +57,10 @@ class FetchCommand extends Command {
   public workspace!: string
 
   @Command.Boolean(`-K,--keep-encode`)
-  public keep_encode: boolean = false
+  public keepEncode: boolean = false
 
-  @Command.Boolean(`-i,--ignore-specs`)
-  public ignore_specs: boolean = false
+  @Command.Boolean(`-I,--ignore-specs`)
+  public ignoreSpecs: boolean = false
 
   @Command.Path(`fetch`)
   public async execute(): Promise<void> {
@@ -76,8 +76,8 @@ class WipeCommand extends Command {
   @Command.String({ required: true })
   public workspace!: string
 
-  @Command.Boolean(`-i,--ignore-specs`)
-  public ignore_specs: boolean = false
+  @Command.Boolean(`-I,--ignore-specs`)
+  public ignoreSpecs: boolean = false
 
   @Command.Path(`wipe`)
   public async execute(): Promise<void> {


### PR DESCRIPTION
This PR adds `-I, --ignore-specs` to wipe, deploy, and fetch
It can also be set in the cli.conf with ignore_specs = true

when active specs will be ignored, so specs on the filesystem can be managed by a CI/CD system.