### PR TITLE
fix(RestClient) file limit and error message

### DIFF
--- a/src/core/HTTP/RestClient.ts
+++ b/src/core/HTTP/RestClient.ts
@@ -57,6 +57,7 @@ export default class RestClient {
     this.client = axios.create({
       baseURL: this.clientUrl,
       headers: this.clientHeaders,
+      maxContentLength: 10 * 1000000, // 10mb is kong file system
       httpsAgent,
     })
   }
@@ -110,6 +111,9 @@ export default class RestClient {
   }
 
   public handleError<T>(err: AxiosError): string {
+    if (err.message === 'Request body larger than maxBodyLength limit') {
+      return '\nFiles must be less than 10mb'
+    }
     if (err.response && err.response.status === 401) {
       return err.message + '\n\t Make sure you have the correct admin token and RBAC settings for that token'
     }


### PR DESCRIPTION
![Screen Shot 2020-08-05 at 10 56 08 AM](https://user-images.githubusercontent.com/15886900/89447309-a076b380-d70a-11ea-94d2-ac5dfb48552b.png)

This PR sets MaxContentLength to equal kong file system limit, as well as provide a nice error when you exceed the limit