### PR TITLE
feat(init) add new ´init´ command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Add new command `init` to initialize a local workspace with a default cli.conf.yaml configuration file
+
 ## [3.2.0] - 2021-07-14
 ### Changed
 - File size limit for uploaded files set to 10MB
 
 ### Fixed
 - Deploy script terminates with exit code 1 when an error occurs
-## [Unreleased]
-### Added
-- Add new command `init` to initialize a local workspace with a default cli.conf.yaml configuration file
 
 ## [3.1.0] - 2020-06-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Deploy script terminates with exit code 1 when an error occurs
+## [Unreleased]
+### Added
+- Add new command `init` to initialize a local workspace with a default cli.conf.yaml configuration file
 
 ## [3.1.0] - 2020-06-15
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Where `<command>` is one of:
  - `disable`   Disable the portal on the given workspace.
  - `enable`    Enable the portal on the given workspace.
  - `fetch`     Fetches content and themes from the given workspace.
+ - `init`      Initialize a local workspace with a default cli.conf.yaml configuration file.
  - `wipe`      Deletes all content and themes from upstream workspace.
 
  Where `<workspace>` indicates the directory/workspace pairing you would like to operate on.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,33 @@
+import * as fs from 'fs-extra'
+import { join } from 'upath'
+
+import File from '../core/File'
+
+const cliConf: string =`# Kong Admin URL
+# @required
+kong_admin_url: http://localhost:8001
+
+# Kong Admin Token
+# @optional
+kong_admin_token: ''`
+
+export default async (args): Promise<void> => {
+
+  let path = join("workspaces", args.workspace)
+
+  await fs.mkdir(path, { recursive: true }, (err) => {
+    if (err) throw err
+  })
+
+  let file: File = new File(join(path, "cli.conf.yaml"), path)
+
+  if (await file.exists()) {
+    console.log("cli.conf.yaml already exist in workspace '" + args.workspace + "'")
+  } else {
+    file.write(cliConf)
+
+    console.log("")
+    console.log("Workspace '" + args.workspace + "' initialized.")
+  }
+  
+}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,7 +3,7 @@ import { join } from 'upath'
 
 import File from '../core/File'
 
-const cliConf: string =`# Kong Admin URL
+const cliConf = `# Kong Admin URL
 # @required
 kong_admin_url: http://localhost:8001
 
@@ -12,22 +12,18 @@ kong_admin_url: http://localhost:8001
 kong_admin_token: ''`
 
 export default async (args): Promise<void> => {
+  let path = join('workspaces', args.workspace)
 
-  let path = join("workspaces", args.workspace)
+  await fs.ensureDir(path)
 
-  await fs.mkdir(path, { recursive: true }, (err) => {
-    if (err) throw err
-  })
-
-  let file: File = new File(join(path, "cli.conf.yaml"), path)
+  let file: File = new File(join(path, 'cli.conf.yaml'), path)
 
   if (await file.exists()) {
     console.log("cli.conf.yaml already exist in workspace '" + args.workspace + "'")
   } else {
     file.write(cliConf)
 
-    console.log("")
+    console.log('')
     console.log("Workspace '" + args.workspace + "' initialized.")
   }
-  
 }

--- a/src/portal.ts
+++ b/src/portal.ts
@@ -2,6 +2,7 @@
 
 import { Cli, Command } from 'clipanion'
 
+import Init from './commands/init'
 import Deploy from './commands/deploy'
 import Wipe from './commands/wipe'
 import Fetch from './commands/fetch'
@@ -16,6 +17,23 @@ const cli = new Cli({
   binaryName: `portal`,
   binaryVersion: packageJson.version,
 })
+
+class InitCommand extends Command {
+  public static usage = Command.Usage({
+    description: 'Initialize a local workspace with a default \`cli.conf.yaml\` configuration file.',
+    details: `
+    This command will initialize a local workspace with a default \`cli.conf.yaml\` configuration file. \n
+    `,
+  })
+
+  @Command.String({ required: true })
+  public workspace!: string
+
+  @Command.Path(`init`)
+  public async execute(): Promise<void> {
+    await Init(this)
+  }
+}
 
 class DeployCommand extends Command {
   public static usage = Command.Usage({
@@ -181,6 +199,7 @@ class HelpCommand extends Command {
   }
 }
 
+cli.register(InitCommand)
 cli.register(DisableCommand)
 cli.register(EnableCommand)
 cli.register(ConfigCommand)


### PR DESCRIPTION
Add new command  to initialize a local workspace with a default cli.conf.yaml configuration file