### PR TITLE
re-throw caught exception so exit code isn't lost

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -102,7 +102,7 @@ async function Deploy(workspace: Workspace, path?: any): Promise<void> {
   } catch (e) {
     spinner.text = client.handleError(e)
     spinner.fail()
-    return
+    throw e
   }
 }
 


### PR DESCRIPTION
This has not been tested. if it works, it resolves #52