### PR TITLE
Use keepalive on requests to the portal to improve performance

### DIFF
--- a/src/core/HTTP/RestClient.ts
+++ b/src/core/HTTP/RestClient.ts
@@ -3,6 +3,8 @@ import { OutgoingHttpHeaders, IRestResponse, IRestResource } from './RestInterfa
 import FileResource, { FileResourceJSON } from './Resources/FileResource'
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios'
 import * as https from 'https'
+import { Agent as HTTPAgent } from 'http'
+import { Agent as HTTPSAgent } from 'https'
 
 export class RestClientError<T> extends Error {
   public response: IRestResponse<T>
@@ -49,14 +51,20 @@ export default class RestClient {
     let httpsAgent
 
     if (workspaceConfig.disableSSLVerification) {
-      httpsAgent = new https.Agent({
+      httpsAgent = new HTTPSAgent({
         rejectUnauthorized: false,
+        keepAlive: true,
+      })
+    } else {
+      httpsAgent = new HTTPSAgent({
+        keepAlive: true,
       })
     }
 
     this.client = axios.create({
       baseURL: this.clientUrl,
       headers: this.clientHeaders,
+      httpAgent: new HTTPAgent({ keepAlive: true }),
       maxContentLength: 10 * 1000000, // 10mb is kong file system
       httpsAgent,
     })


### PR DESCRIPTION
Hi Folks, 

Our team has been using the portal CLI quite a bit to push templates. We've noticed that the tool creates a huge amount of connections to our instances which has caused some issues. This PR introduces the keepalive attribute to Axios client creation. This should improve performance when interacting with the API endpoint. 