### PR TITLE
feat(client) MaxContentLength configurable field

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Where `<command>` is one of:
 In addition to `kong_admin_uri` and `kong_admin_token`, you can also add:
 - `disable_ssl_verification: true` and
 - `ignore_specs: true`
-- `maxContentLengthInMb` - maximum size allowed to be transferred in Mb - default is 10 (10Mb)
+- `max_content_length_mb` - maximum size allowed to be transferred in Mb - default is 10 (10Mb)
 
 Set the options in the CLI configuration file to always enable those settings on that Workspace instead of passing the option flags with every command.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Where `<command>` is one of:
 In addition to `kong_admin_uri` and `kong_admin_token`, you can also add:
 - `disable_ssl_verification: true` and
 - `ignore_specs: true`
+- `maxContentLengthInMb` - maximum size allowed to be transferred in Mb - default is 10 (10Mb)
 
 Set the options in the CLI configuration file to always enable those settings on that Workspace instead of passing the option flags with every command.
 

--- a/src/core/HTTP/RestClient.ts
+++ b/src/core/HTTP/RestClient.ts
@@ -1,9 +1,10 @@
-import WorkspaceConfig, { IWorkspaceConfig } from '../WorkspaceConfig'
+import { IWorkspaceConfig } from '../WorkspaceConfig'
 import { IRestResponse } from './RestInterfaces'
 import FileResource, { FileResourceJSON } from './Resources/FileResource'
 import axios, { AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios'
 import { Agent as HTTPAgent } from 'http'
 import { Agent as HTTPSAgent } from 'https'
+import { MAX_CONTENT_LENGTH_MB, ONE_MB } from '../constants'
 
 export class RestClientError<T> extends Error {
   public response: IRestResponse<T>
@@ -64,9 +65,7 @@ export default class RestClient {
       headers: this.clientHeaders,
       httpAgent: new HTTPAgent({ keepAlive: true, maxSockets: 10 }),
       maxContentLength:
-        (workspaceConfig.maxContentLengthInMb
-          ? workspaceConfig.maxContentLengthInMb
-          : WorkspaceConfig.MAX_CONTENT_LENGTH_MB) * WorkspaceConfig.ONE_MB,
+        (workspaceConfig.maxContentLengthInMb ? workspaceConfig.maxContentLengthInMb : MAX_CONTENT_LENGTH_MB) * ONE_MB,
       httpsAgent,
     })
   }

--- a/src/core/HTTP/RestClient.ts
+++ b/src/core/HTTP/RestClient.ts
@@ -1,4 +1,4 @@
-import { IWorkspaceConfig } from '../WorkspaceConfig'
+import WorkspaceConfig, { IWorkspaceConfig } from '../WorkspaceConfig'
 import { IRestResponse } from './RestInterfaces'
 import FileResource, { FileResourceJSON } from './Resources/FileResource'
 import axios, { AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios'
@@ -63,7 +63,10 @@ export default class RestClient {
       baseURL: this.clientUrl,
       headers: this.clientHeaders,
       httpAgent: new HTTPAgent({ keepAlive: true, maxSockets: 10 }),
-      maxContentLength: (workspaceConfig.maxContentLengthInMb ? workspaceConfig.maxContentLengthInMb : 10) * 1000000, // 10mb (default) is kong file system
+      maxContentLength:
+        (workspaceConfig.maxContentLengthInMb
+          ? workspaceConfig.maxContentLengthInMb
+          : WorkspaceConfig.MAX_CONTENT_LENGTH_MB) * WorkspaceConfig.ONE_MB,
       httpsAgent,
     })
   }

--- a/src/core/HTTP/RestClient.ts
+++ b/src/core/HTTP/RestClient.ts
@@ -5,7 +5,6 @@ import axios, { AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios'
 import { Agent as HTTPAgent } from 'http'
 import { Agent as HTTPSAgent } from 'https'
 
-
 export class RestClientError<T> extends Error {
   public response: IRestResponse<T>
 

--- a/src/core/HTTP/RestClient.ts
+++ b/src/core/HTTP/RestClient.ts
@@ -63,7 +63,7 @@ export default class RestClient {
     this.client = axios.create({
       baseURL: this.clientUrl,
       headers: this.clientHeaders,
-      httpAgent: new HTTPAgent({ keepAlive: true, maxSockets: 10 }),
+      httpAgent: new HTTPAgent({ keepAlive: true }),
       maxContentLength:
         (workspaceConfig.maxContentLengthInMb ? workspaceConfig.maxContentLengthInMb : MAX_CONTENT_LENGTH_MB) * ONE_MB,
       httpsAgent,

--- a/src/core/HTTP/RestClient.ts
+++ b/src/core/HTTP/RestClient.ts
@@ -5,6 +5,7 @@ import axios, { AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios'
 import { Agent as HTTPAgent } from 'http'
 import { Agent as HTTPSAgent } from 'https'
 
+
 export class RestClientError<T> extends Error {
   public response: IRestResponse<T>
 
@@ -62,8 +63,8 @@ export default class RestClient {
     this.client = axios.create({
       baseURL: this.clientUrl,
       headers: this.clientHeaders,
-      httpAgent: new HTTPAgent({ keepAlive: true }),
-      maxContentLength: 10 * 1000000, // 10mb is kong file system
+      httpAgent: new HTTPAgent({ keepAlive: true, maxSockets: 10 }),
+      maxContentLength: (workspaceConfig.maxContentLengthInMb ? workspaceConfig.maxContentLengthInMb : 10) * 1000000, // 10mb (default) is kong file system
       httpsAgent,
     })
   }

--- a/src/core/WorkspaceConfig.ts
+++ b/src/core/WorkspaceConfig.ts
@@ -16,6 +16,9 @@ export interface IWorkspaceConfig {
 }
 
 export default class WorkspaceConfig extends Config implements IWorkspaceConfig {
+  public static readonly MAX_CONTENT_LENGTH_MB = 10 // 10mb (default) is kong file system
+  public static readonly ONE_MB = 1000000
+
   /**
    * @deprecated
    */

--- a/src/core/WorkspaceConfig.ts
+++ b/src/core/WorkspaceConfig.ts
@@ -16,9 +16,6 @@ export interface IWorkspaceConfig {
 }
 
 export default class WorkspaceConfig extends Config implements IWorkspaceConfig {
-  public static readonly MAX_CONTENT_LENGTH_MB = 10 // 10mb (default) is kong file system
-  public static readonly ONE_MB = 1000000
-
   /**
    * @deprecated
    */

--- a/src/core/WorkspaceConfig.ts
+++ b/src/core/WorkspaceConfig.ts
@@ -101,10 +101,10 @@ export default class WorkspaceConfig extends Config implements IWorkspaceConfig 
   }
 
   public set maxContentLengthInMb(maxContentLengthInMb: number) {
-    this.data['maxContentLengthInMb'] = maxContentLengthInMb
+    this.data['max_content_length_mb'] = maxContentLengthInMb
   }
 
   public get maxContentLengthInMb(): number {
-    return this.data.maxContentLengthInMb
+    return this.data.max_content_length_mb
   }
 }

--- a/src/core/WorkspaceConfig.ts
+++ b/src/core/WorkspaceConfig.ts
@@ -12,6 +12,7 @@ export interface IWorkspaceConfig {
   disableSSLVerification?: boolean
   ignoreSpecs?: boolean
   skipPaths?: string[]
+  maxContentLengthInMb?: number
 }
 
 export default class WorkspaceConfig extends Config implements IWorkspaceConfig {
@@ -97,5 +98,13 @@ export default class WorkspaceConfig extends Config implements IWorkspaceConfig 
 
   public get skipPaths(): string[] {
     return this.data.skip_paths
+  }
+
+  public set maxContentLengthInMb(maxContentLengthInMb: number) {
+    this.data['maxContentLengthInMb'] = maxContentLengthInMb
+  }
+
+  public get maxContentLengthInMb(): number {
+    return this.data.maxContentLengthInMb
   }
 }

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,0 +1,2 @@
+export const MAX_CONTENT_LENGTH_MB = 10 // 10mb (default) is kong file system
+export const ONE_MB = 1000000


### PR DESCRIPTION
Created a new cli.conf.yaml field to set the MaxContentLength value for the REST client used when upload or reading files using portal CLI tool