### PR TITLE
fix(sync): use continue instead of return when ignoring specs

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -91,7 +91,7 @@ async function Sync(workspace: Workspace, args: ISyncArguments, options: ISyncOp
 
     for (const [group, files] of Object.entries(fileGroups)) {
       if (group === GroupType.specs && workspace.config.ignoreSpecs) {
-        return
+        continue
       }
 
       // check skipPaths


### PR DESCRIPTION
Fixes issue where --ignore-specs flag causes the rest of the fileGroups to be skipped also.